### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/action.php
+++ b/action.php
@@ -23,7 +23,7 @@ class action_plugin_fbcomments extends DokuWiki_Action_Plugin {
                     );
     }
 
-    function register(&$controller) {
+    function register(Doku_Event_Handler $controller) {
         $controller->register_hook('TPL_METAHEADER_OUTPUT', 'BEFORE', $this,'_addHeader');
     }
     function _addHeader(&$event, $param){

--- a/syntax.php
+++ b/syntax.php
@@ -49,7 +49,7 @@ class syntax_plugin_fbcomments extends DokuWiki_Syntax_Plugin {
       $this->Lexer->addSpecialPattern('\{\{fbc>[^}]*\}\}',$mode,'plugin_fbcomments');      
    }
    
-   function handle($match, $state, $pos, &$handler){
+   function handle($match, $state, $pos, Doku_Handler $handler){
       if (isset($_REQUEST['comment'])) return false;
       
       $match= substr($match, 6, -2);
@@ -69,7 +69,7 @@ class syntax_plugin_fbcomments extends DokuWiki_Syntax_Plugin {
         return $data;
    }
    
-   function render($mode, &$renderer, $data){
+   function render($mode, Doku_Renderer $renderer, $data){
      if($mode == 'xhtml'){
        $renderer->doc .= $this->_commentsBox($data);
        


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.